### PR TITLE
Fix .mergify.yml; don't merge when a test failed

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -9,6 +9,7 @@ pull_request_rules:
       - base=master
       - "#approved-reviews-by>=1"
       - status-success~=Test Julia .*
+      - -status-failure~=Test Julia [0-9].*
       - label=ready-to-merge:squash
       - label!=work-in-progress
     actions:
@@ -19,6 +20,7 @@ pull_request_rules:
       - base=master
       - "#approved-reviews-by>=1"
       - status-success~=Test Julia .*
+      - -status-failure~=Test Julia [0-9].*
       - label=ready-to-merge:rebase
       - label!=work-in-progress
     actions:
@@ -29,6 +31,7 @@ pull_request_rules:
       - base=master
       - "#approved-reviews-by>=1"
       - status-success~=Test Julia .*
+      - -status-failure~=Test Julia [0-9].*
       - label=ready-to-merge:merge
       - label!=work-in-progress
     actions:
@@ -39,6 +42,7 @@ pull_request_rules:
       - author=tkf
       - base=master
       - status-success~=Test Julia .*
+      - -status-failure~=Test Julia [0-9].*
       - label~=ready-to-merge:.*
     actions:
       review: {}


### PR DESCRIPTION
The previous setting was too loose.  It only required at least one test job passes.

Ref:
https://github.com/tkf/BenchmarkCI.jl/pull/43
https://github.com/tkf/Restacker.jl/pull/9